### PR TITLE
Added fix for missing /etc/puppet/tmp directory error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class limits(
   $fragments_dir = '/etc/puppet/tmp/limits_fragments.d/'
   $tmp_limits_conf = '/etc/puppet/tmp/limits.conf'
 
-  file { $fragments_dir:
+  file { [ '/etc/puppet/tmp', $fragments_dir ]:
     ensure  => directory,
     recurse => true,
     purge   => true,


### PR DESCRIPTION
The tmp directory does not seem to be a standard directory in /etc/puppet (this seems to be the case for ubuntu 12.04 and the rpm package distributed by puppetlabs), so I added a resource to create if it wasn't there. 

Otherwise I get this error:

Error: Cannot create /etc/puppet/tmp/limits_fragments.d; parent directory /etc/puppet/tmp does not exist
Error: /Stage[main]/Limits/File[/etc/puppet/tmp/limits_fragments.d/]/ensure: change from absent to directory failed: Cannot create /etc/puppet/tmp/limits_fragments.d; parent directory /etc/puppet/tmp does not exist
