### PR TITLE
Cleanup $fragments_dir only after copying new limits.conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,19 +11,17 @@ class limits(
   $limits_file = '/etc/security/limits.conf'
 ) {
 
-  $fragments_dir = '/etc/puppet/tmp/limits_fragments.d/'
+  $fragments_dir = '/etc/puppet/tmp/limits_fragments.d'
   $tmp_limits_conf = '/etc/puppet/tmp/limits.conf'
 
   file { [ '/etc/puppet/tmp', $fragments_dir ]:
     ensure  => directory,
-    recurse => true,
-    purge   => true,
     owner   => 'puppet',
     group   => 'puppet',
     mode    =>  '600',
   }
   exec { 'cp_limits':
-    command => "/bin/cp ${tmp_limits_conf} ${limits_file}",
+    command => "/bin/cp ${tmp_limits_conf} ${limits_file} && /bin/rm ${fragments_dir}/*",
     onlyif  => "/bin/cat ${fragments_dir}/* > ${tmp_limits_conf} && ! diff ${tmp_limits_conf} ${limits_file}",
     require => File[$fragments_dir]
   }


### PR DESCRIPTION
I use this module in combination with foreman and i was irritated that my machines are active all the time.

I suggest to only remove the old files when something has changed.
