### PR TITLE
Ensure we use a string, needed for Puppet 4

### DIFF
--- a/manifests/fragment.pp
+++ b/manifests/fragment.pp
@@ -46,7 +46,7 @@ define limits::fragment (
     fail("invalid limits format: ${limit_domain}/${limit_type}/${limit_item}")
   }
 
-  if ( $value and $value !~ /^([A-Za-z0-9_.\/-]+)$/ ) {
+  if ( $value and "${value}" !~ /^([A-Za-z0-9_.\/-]+)$/ ) {
     fail("invalid value for limits: ${value}. See man 5 limits.conf")
   }
 


### PR DESCRIPTION
With Puppet 4 and its new Integer type, that class fails:

Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Evaluation Error: Left match operand must result in a String
value. Got an Integer. at
/etc/puppetlabs/code/environments/production/modules/limits/manifests/fragment.pp:49:19
on node foo.inuits.eu

This commits converts them to a string to ensure compatibility with both
versions.
