### PR TITLE
Manage limits.d directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,11 +4,23 @@
 #
 # Parameters:
 #  - final file to be written to
+#  - directory to manage on RedHat
 #
 # Actions:
 #
 class limits(
-  $limits_file = '/etc/security/limits.conf'
+  $limits_file = '/etc/security/limits.conf',
+  $limits_dir = '/etc/security/limits.d/'
 ) {
-
+  if $::osfamily == 'RedHat' {
+    file { $limits_dir:
+      ensure  => directory,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0755',
+      recurse => true,
+      purge   => true,
+      force   => true
+    }
+  }
 }


### PR DESCRIPTION
Currently when we add entries to the limits.conf file, those changes might not be in effect because they are overwritten in files in the limits.d directory. For example on RHEL systems there is an nproc.conf that sets a soft limit for all users.
To make sure the entries via this module are the ones being used, we should manage the limits.d directory and remove all files not being managed by puppet.
Notice: The limits.d directory does not exist on all systems, e.g. SUSE does not have it, so we only implement it on RHEL for now, let me know if you know other distributions where this should be managed.